### PR TITLE
feat(autonomous-grid): add container image for Grid local mode

### DIFF
--- a/apps/autonomous-grid/Dockerfile
+++ b/apps/autonomous-grid/Dockerfile
@@ -1,0 +1,39 @@
+ARG VERSION
+FROM python:3.12-slim
+
+ARG TARGETPLATFORM
+ARG VERSION
+ARG CHANNEL
+
+ENV HOME=/config \
+    GRID_HOME=/config/.grid \
+    GRID_NAME=home \
+    GRID_PORT=8090 \
+    GRID_HOST=0.0.0.0
+
+WORKDIR /app
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install the grid wheel from the GitHub release
+RUN pip install --no-cache-dir \
+    "https://github.com/autonomous-ai/autonomous-grid/releases/download/v${VERSION}/grid-${VERSION}-py3-none-any.whl"
+
+COPY entrypoint.sh /app/entrypoint.sh
+
+# Create non-root user
+RUN groupadd -g 1000 grid && \
+    useradd -u 1000 -g 1000 -d /config -s /bin/sh grid && \
+    mkdir -p /config/.grid && \
+    chown -R 1000:1000 /config
+
+USER 1000
+
+EXPOSE 8090
+
+LABEL org.opencontainers.image.source="https://github.com/autonomous-ai/autonomous-grid"
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/apps/autonomous-grid/Dockerfile
+++ b/apps/autonomous-grid/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update && \
 RUN pip install --no-cache-dir \
     "https://github.com/autonomous-ai/autonomous-grid/releases/download/v${VERSION}/grid-${VERSION}-py3-none-any.whl"
 
-COPY entrypoint.sh /app/entrypoint.sh
+COPY apps/autonomous-grid/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 
 # Create non-root user
 RUN groupadd -g 1000 grid && \

--- a/apps/autonomous-grid/ci/goss.yaml
+++ b/apps/autonomous-grid/ci/goss.yaml
@@ -1,0 +1,12 @@
+command:
+  python-version:
+    exec: "python --version"
+    exit-status: 0
+    stdout:
+      - "Python 3.12"
+
+  grid-installed:
+    exec: "grid --version"
+    exit-status: 0
+    stdout:
+      - "grid"

--- a/apps/autonomous-grid/ci/goss.yaml
+++ b/apps/autonomous-grid/ci/goss.yaml
@@ -1,12 +1,9 @@
-command:
-  python-version:
-    exec: "python --version"
-    exit-status: 0
-    stdout:
-      - "Python 3.12"
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/goss-org/goss/master/docs/schema.yaml
+port:
+  tcp:8090:
+    listening: true
 
-  grid-installed:
-    exec: "grid --version"
-    exit-status: 0
-    stdout:
-      - "grid"
+http:
+  http://localhost:8090/v1/models:
+    status: 200

--- a/apps/autonomous-grid/ci/latest.sh
+++ b/apps/autonomous-grid/ci/latest.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+version="$(curl -sL -o /dev/null -w '%{url_effective}' "https://github.com/autonomous-ai/autonomous-grid/releases/latest" | grep -oP 'v\K[^/]+')"
+printf "%s" "${version}"

--- a/apps/autonomous-grid/ci/latest.sh
+++ b/apps/autonomous-grid/ci/latest.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
-version="$(curl -sL -o /dev/null -w '%{url_effective}' "https://github.com/autonomous-ai/autonomous-grid/releases/latest" | grep -oP 'v\K[^/]+')"
+version="$(curl -sX GET "https://api.github.com/repos/autonomous-ai/autonomous-grid/releases/latest" | jq --raw-output '.tag_name' 2>/dev/null)"
+version="${version#*v}"
 printf "%s" "${version}"

--- a/apps/autonomous-grid/entrypoint.sh
+++ b/apps/autonomous-grid/entrypoint.sh
@@ -1,35 +1,55 @@
 #!/bin/sh
 set -e
 
-# Initialize the grid in local mode and run the server in the foreground.
-# grid up normally detaches; we use the internal __server command directly
-# after initializing the config via `grid up` (which will fail to health-check
-# since it expects detached mode, but the config will be written).
-
 export GRID_HOME="${GRID_HOME:-/config/.grid}"
+export HOME="${HOME:-/config}"
 
-# Ensure local mode
-grid mode local 2>/dev/null || true
+# Ensure state directory exists
+mkdir -p "${GRID_HOME}"
 
-# Create the grid config if it doesn't exist, then run the server foreground.
-# We use python to call the server directly since `grid up` spawns a daemon.
+# Force local mode by writing the state file
+cat > "${GRID_HOME}/state.json" <<EOF
+{"mode": "local", "local_active_grid": null, "remote_active_grid": null}
+EOF
+
+# Run the grid server directly via Python — grid up spawns a daemon which
+# doesn't work in a container. We initialize config and run uvicorn in foreground.
 exec python -c "
-import uvicorn
-from local.server import create_app
-from local import config, runtime
+import os, json, uuid
+from pathlib import Path
+from datetime import datetime, timezone
 
-import os
-
+# Minimal grid config initialization without relying on grid CLI plumbing
+grid_home = Path(os.environ.get('GRID_HOME', '/config/.grid'))
 name = os.environ.get('GRID_NAME', 'home')
 port = int(os.environ.get('GRID_PORT', '8090'))
 host = os.environ.get('GRID_HOST', '0.0.0.0')
 
-# Initialize grid config
-cfg = config.select_grid(name)
-if not cfg:
-    cfg = runtime.init_grid_config(name=name, port=port, host=host)
-    config.select_grid_by_id(cfg['grid_id'])
+grid_id = f'ag-{name}-{uuid.uuid4().hex[:8]}'
+grids_dir = grid_home / 'grids' / grid_id
+grids_dir.mkdir(parents=True, exist_ok=True)
 
-app = create_app(grid_id=cfg['grid_id'], grid_name=cfg['name'])
+cfg = {
+    'grid_id': grid_id,
+    'name': name,
+    'grid_type': 'lan-permissionless',
+    'managed_server': True,
+    'host': host,
+    'port': port,
+    'lan_signaling_url': f'http://{host}:{port}',
+    'server_pid': os.getpid(),
+    'created_at': datetime.now(timezone.utc).isoformat(),
+    'updated_at': datetime.now(timezone.utc).isoformat(),
+}
+
+(grids_dir / 'config.json').write_text(json.dumps(cfg, indent=2))
+
+# Update state to point at this grid
+state = {'mode': 'local', 'local_active_grid': grid_id, 'remote_active_grid': None}
+(grid_home / 'state.json').write_text(json.dumps(state, indent=2))
+
+import uvicorn
+from local.server import create_app
+app = create_app(grid_id=grid_id, grid_name=name)
 uvicorn.run(app, host=host, port=port)
 "

--- a/apps/autonomous-grid/entrypoint.sh
+++ b/apps/autonomous-grid/entrypoint.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+# Initialize the grid in local mode and run the server in the foreground.
+# grid up normally detaches; we use the internal __server command directly
+# after initializing the config via `grid up` (which will fail to health-check
+# since it expects detached mode, but the config will be written).
+
+export GRID_HOME="${GRID_HOME:-/config/.grid}"
+
+# Ensure local mode
+grid mode local 2>/dev/null || true
+
+# Create the grid config if it doesn't exist, then run the server foreground.
+# We use python to call the server directly since `grid up` spawns a daemon.
+exec python -c "
+import uvicorn
+from local.server import create_app
+from local import config, runtime
+
+import os
+
+name = os.environ.get('GRID_NAME', 'home')
+port = int(os.environ.get('GRID_PORT', '8090'))
+host = os.environ.get('GRID_HOST', '0.0.0.0')
+
+# Initialize grid config
+cfg = config.select_grid(name)
+if not cfg:
+    cfg = runtime.init_grid_config(name=name, port=port, host=host)
+    config.select_grid_by_id(cfg['grid_id'])
+
+app = create_app(grid_id=cfg['grid_id'], grid_name=cfg['name'])
+uvicorn.run(app, host=host, port=port)
+"

--- a/apps/autonomous-grid/metadata.yaml
+++ b/apps/autonomous-grid/metadata.yaml
@@ -1,0 +1,9 @@
+app: autonomous-grid
+semver: true
+channels:
+  - name: stable
+    platforms: ["linux/amd64", "linux/arm64"]
+    stable: true
+    tests:
+      enabled: true
+      type: cli


### PR DESCRIPTION
## Summary

Adds a container image for [autonomous-grid](https://github.com/autonomous-ai/autonomous-grid) — an OpenAI-compatible proxy that pools multiple inference engines (Ollama, vLLM, llama.cpp, MLX, etc.) behind a single endpoint with load-aware routing.

## What this does

- Installs the `grid` Python wheel from upstream GitHub releases into a `python:3.12-slim` image
- Runs the Grid server in **local mode** (no auth, no external dependencies, LAN-only)
- Exposes port 8090 with an OpenAI-compatible `/v1` endpoint
- Runs as UID 1000
- Multi-arch: linux/amd64 + linux/arm64

## Usage

Once deployed, external machines can register their inference engines with:
```bash
grid join http://<grid-endpoint>:8090 --at http://localhost:11434/v1 -m <model> --name <engine-name>
```

Any OpenAI-compatible client can then consume from the single grid endpoint.